### PR TITLE
Rotate creds every N hours

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -7,11 +7,15 @@ terraform {
   }
 }
 
+resource "time_rotating" "rotate_every_n_hours" {
+  rotation_hours = var.rotate_every_n_hours
+}
+
 # Refresh our Doormat credentials
 resource "null_resource" "doormat-refresh" {
   # Run every time
   triggers = {
-    timestamp = timestamp()
+    rotation = time_rotating.rotate_every_n_hours.unix
   }
 
   provisioner "local-exec" {
@@ -24,7 +28,7 @@ resource "null_resource" "doormat-refresh" {
 resource "null_resource" "push-creds" {
   # Run every time
   triggers = {
-    timestamp = timestamp()
+    rotation = time_rotating.rotate_every_n_hours.unix
   }
 
   # Ensure we have valid Doormat creds first

--- a/variables.tf
+++ b/variables.tf
@@ -12,3 +12,9 @@ variable "tfc_workspace" {
   type        = string
   description = "The TFC Workspace to push credentials to"
 }
+
+variable "rotate_every_n_hours" {
+  type        = number
+  description = "How frequently should the provider run a doormat refresh and push new creds to TFC?"
+  default     = 1
+}


### PR DESCRIPTION
Every hour:

```
  # module.creds["dev"].null_resource.doormat-refresh must be replaced
-/+ resource "null_resource" "doormat-refresh" {
      ~ id       = "2211241149228208893" -> (known after apply)
      ~ triggers = {
          - "rotation" = "1634648911"
        } -> (known after apply) # forces replacement
    }

  # module.creds["dev"].null_resource.push-creds must be replaced
-/+ resource "null_resource" "push-creds" {
      ~ id       = "4565193638576839922" -> (known after apply)
      ~ triggers = {
          - "rotation" = "1634648911"
        } -> (known after apply) # forces replacement
    }

  # module.creds["dev"].time_rotating.rotate_every_n_hours will be created
  + resource "time_rotating" "rotate_every_n_hours" {
      + day              = (known after apply)
      + hour             = (known after apply)
      + id               = (known after apply)
      + minute           = (known after apply)
      + month            = (known after apply)
      + rfc3339          = (known after apply)
      + rotation_hours   = 1
      + rotation_rfc3339 = (known after apply)
      + second           = (known after apply)
      + unix             = (known after apply)
      + year             = (known after apply)
    }
```

Between hours:

```
No changes. Your infrastructure matches the configuration.
```